### PR TITLE
Fix typos in Portuguese site

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -9,7 +9,7 @@
 
 <head>
 	<title>Yuri Padua - Portfolio | Tecnologia, Apps, and Soluções</title>
-	<h1 id="logo"><a href="https://yuripadua.github.io">Yuri Padua's Portifolio</a></h1>
+	<h1 id="logo"><a href="https://yuripadua.github.io">Yuri Padua's Portfólio</a></h1>
 
 	<meta charset="utf-8" />
 	<meta name="description"
@@ -100,7 +100,7 @@
 		<section id="banner">
 			<div class="content">
 				<header>
-					<h2>Bem vindo ao portifólio de Yuri Padua</h2>
+					<h2>Bem vindo ao portfólio de Yuri Padua</h2>
 					<b>
 						<p>The future has landed...
 							And there are no hoverboards or flying cars.<br />
@@ -121,7 +121,7 @@
 						<div class="col-4 col-12-medium">
 							<header>
 								<h2>Neste mundo dominado pela tecnologia...</h2>
-								<p>Parceiros aptos farão a difença entre sucesso e fracasso nos negócios!</p>
+								<p>Parceiros aptos farão a diferença entre sucesso e fracasso nos negócios!</p>
 							</header>
 						</div>
 						<div class="col-4 col-12-medium">
@@ -191,7 +191,7 @@
 		<section id="four" class="wrapper style1 special fade-up">
 			<div class="container">
 				<header class="major">
-					<h2>Conheça alguns dos projetos no portifólio</h2>
+					<h2>Conheça alguns dos projetos no portfólio</h2>
 					<p>Cada projeto o direcionará para uma página com o projeto e seu respectivo repositório abaixo</p>
 				</header>
 				<div class="box alt">
@@ -201,7 +201,7 @@
 							<img src="../images/nodejs.png" alt="Node.js"
 								style="width: 6em; height: 6em; border-radius: 50%; object-fit: contain;">
 							<h3>API RESTFULL Node.JS</h3>
-							<p>Demosntração de webapp para e-commerce.</p>
+							<p>Demonstração de webapp para e-commerce.</p>
 						</section>
 						<section class="col-4 col-6-medium col-12-xsmall">
 							<!-- <span class="icon major alt my-php-logo"></span> -->
@@ -215,7 +215,7 @@
 							<img src="../images/django-python-logo.webp" alt="django-python"
 								style="width: 6em; height: 6em; border-radius: 50%; object-fit: contain;">
 							<h3>API RESTFULL Python</h3>
-							<p>Demonstação em construção.</p>
+							<p>Demonstração em construção.</p>
 						</section>
 						<section class="col-4 col-6-medium col-12-xsmall">
 							<!-- <span class="icon major alt my-flutter-logo"></span> -->


### PR DESCRIPTION
## Summary
- fix misspelled headings in `pt/index.html`

## Testing
- `npm test` *(fails: could not find package.json)*
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_684091db6dc883268e91b6eeb609918e